### PR TITLE
Development -- scheduling

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,8 +4,11 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="1728b123-f064-4bc8-9268-077eb1f560ed" name="Changes" comment="see todos">
+    <list default="true" id="1728b123-f064-4bc8-9268-077eb1f560ed" name="Changes" comment="updated dependencies">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/poetry.lock" beforeDir="false" afterPath="$PROJECT_DIR$/poetry.lock" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pyproject.toml" beforeDir="false" afterPath="$PROJECT_DIR$/pyproject.toml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/production-tastytrade.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/production-tastytrade.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -228,7 +231,8 @@
       <workItem from="1730902848622" duration="1362000" />
       <workItem from="1730930993728" duration="255000" />
       <workItem from="1731075494235" duration="1472000" />
-      <workItem from="1731084404901" duration="1214000" />
+      <workItem from="1731084404901" duration="2938000" />
+      <workItem from="1731087767854" duration="2769000" />
     </task>
     <task id="LOCAL-00001" summary="initial reformat">
       <option name="closed" value="true" />
@@ -414,7 +418,15 @@
       <option name="project" value="LOCAL" />
       <updated>1730821471887</updated>
     </task>
-    <option name="localTasksCounter" value="24" />
+    <task id="LOCAL-00024" summary="updated dependencies">
+      <option name="closed" value="true" />
+      <created>1731085838129</created>
+      <option name="number" value="00024" />
+      <option name="presentableId" value="LOCAL-00024" />
+      <option name="project" value="LOCAL" />
+      <updated>1731085838129</updated>
+    </task>
+    <option name="localTasksCounter" value="25" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -477,7 +489,6 @@
     <MESSAGE value="added main block" />
     <MESSAGE value="minor cleanup" />
     <MESSAGE value="adjusted link in the order dry run as this was incorrect, adjusted authorization" />
-    <MESSAGE value="updated dependencies" />
     <MESSAGE value="added comprehensive logging" />
     <MESSAGE value="log file and directory setup" />
     <MESSAGE value="added docstrings" />
@@ -491,7 +502,8 @@
     <MESSAGE value="implemented the account manager, working on allowing the account manager and the strategy script to work together -- dev continues during market hours." />
     <MESSAGE value="get session token cleanup" />
     <MESSAGE value="see todos" />
-    <option name="LAST_COMMIT_MESSAGE" value="see todos" />
+    <MESSAGE value="updated dependencies" />
+    <option name="LAST_COMMIT_MESSAGE" value="updated dependencies" />
   </component>
   <component name="com.intellij.coverage.CoverageDataManagerImpl">
     <SUITE FILE_PATH="coverage/selling_volatility$account_manager.coverage" NAME="account-manager Coverage Results" MODIFIED="1730821303376" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
@@ -500,6 +512,6 @@
     <SUITE FILE_PATH="coverage/selling_volatility$test.coverage" NAME="test Coverage Results" MODIFIED="1730210511207" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
     <SUITE FILE_PATH="coverage/selling_volatility$test__1_.coverage" NAME="test (1) Coverage Results" MODIFIED="1730494388177" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
     <SUITE FILE_PATH="coverage/selling_volatility$spread_backtest_settlement.coverage" NAME="spread-backtest-settlement Coverage Results" MODIFIED="1729774506154" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
-    <SUITE FILE_PATH="coverage/selling_volatility$production_tastytrade.coverage" NAME="production-tastytrade Coverage Results" MODIFIED="1731076343317" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
+    <SUITE FILE_PATH="coverage/selling_volatility$production_tastytrade.coverage" NAME="production-tastytrade Coverage Results" MODIFIED="1731088813592" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,10 +4,8 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="1728b123-f064-4bc8-9268-077eb1f560ed" name="Changes" comment="get session token cleanup">
+    <list default="true" id="1728b123-f064-4bc8-9268-077eb1f560ed" name="Changes" comment="see todos">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/settings.json" beforeDir="false" afterPath="$PROJECT_DIR$/settings.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/production-tastytrade.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/production-tastytrade.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -45,32 +43,32 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "ASKED_SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "Python.account-manager.executor": "Run",
-    "Python.production-tastytrade.executor": "Run",
-    "Python.spread-production.executor": "Run",
-    "Python.test (1).executor": "Run",
-    "Python.test.executor": "Run",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "git-widget-placeholder": "development",
-    "last_opened_file_path": "C:/Users/marwi/PycharmProjects/selling-volatility",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ASKED_SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;Python.account-manager.executor&quot;: &quot;Run&quot;,
+    &quot;Python.production-tastytrade.executor&quot;: &quot;Run&quot;,
+    &quot;Python.spread-production.executor&quot;: &quot;Run&quot;,
+    &quot;Python.test (1).executor&quot;: &quot;Run&quot;,
+    &quot;Python.test.executor&quot;: &quot;Run&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;development&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/Users/marwi/PycharmProjects/selling-volatility&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="C:\Users\marwi\PycharmProjects\selling-volatility\docs" />
       <recent name="C:\Users\marwi\PycharmProjects\selling-volatility\src\backtest" />
     </key>
   </component>
-  <component name="RunManager" selected="Python.account-manager">
+  <component name="RunManager" selected="Python.production-tastytrade">
     <configuration name="account-manager" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="selling-volatility" />
       <option name="ENV_FILES" value="" />
@@ -188,9 +186,9 @@
     </configuration>
     <recent_temporary>
       <list>
-        <item itemvalue="Python.account-manager" />
         <item itemvalue="Python.production-tastytrade" />
         <item itemvalue="Python.spread-production" />
+        <item itemvalue="Python.account-manager" />
         <item itemvalue="Python.test (1)" />
         <item itemvalue="Python.test" />
       </list>
@@ -226,7 +224,11 @@
       <workItem from="1730568028728" duration="1400000" />
       <workItem from="1730583097656" duration="1554000" />
       <workItem from="1730725505383" duration="5585000" />
-      <workItem from="1730816582951" duration="2420000" />
+      <workItem from="1730816582951" duration="3411000" />
+      <workItem from="1730902848622" duration="1362000" />
+      <workItem from="1730930993728" duration="255000" />
+      <workItem from="1731075494235" duration="1472000" />
+      <workItem from="1731084404901" duration="1214000" />
     </task>
     <task id="LOCAL-00001" summary="initial reformat">
       <option name="closed" value="true" />
@@ -404,7 +406,15 @@
       <option name="project" value="LOCAL" />
       <updated>1730631773346</updated>
     </task>
-    <option name="localTasksCounter" value="23" />
+    <task id="LOCAL-00023" summary="see todos">
+      <option name="closed" value="true" />
+      <created>1730821471887</created>
+      <option name="number" value="00023" />
+      <option name="presentableId" value="LOCAL-00023" />
+      <option name="project" value="LOCAL" />
+      <updated>1730821471887</updated>
+    </task>
+    <option name="localTasksCounter" value="24" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -480,15 +490,16 @@
     <MESSAGE value="added account_monitor_design.md" />
     <MESSAGE value="implemented the account manager, working on allowing the account manager and the strategy script to work together -- dev continues during market hours." />
     <MESSAGE value="get session token cleanup" />
-    <option name="LAST_COMMIT_MESSAGE" value="get session token cleanup" />
+    <MESSAGE value="see todos" />
+    <option name="LAST_COMMIT_MESSAGE" value="see todos" />
   </component>
   <component name="com.intellij.coverage.CoverageDataManagerImpl">
-    <SUITE FILE_PATH="coverage/selling_volatility$account_manager.coverage" NAME="account-manager Coverage Results" MODIFIED="1730821260959" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
+    <SUITE FILE_PATH="coverage/selling_volatility$account_manager.coverage" NAME="account-manager Coverage Results" MODIFIED="1730821303376" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
     <SUITE FILE_PATH="coverage/selling_volatility$spread_production_tastytrade.coverage" NAME="spread-production-tastytrade Coverage Results" MODIFIED="1729865801054" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
-    <SUITE FILE_PATH="coverage/selling_volatility$spread_production.coverage" NAME="spread-production Coverage Results" MODIFIED="1730817273202" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
+    <SUITE FILE_PATH="coverage/selling_volatility$spread_production.coverage" NAME="spread-production Coverage Results" MODIFIED="1731076313875" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
     <SUITE FILE_PATH="coverage/selling_volatility$test.coverage" NAME="test Coverage Results" MODIFIED="1730210511207" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
     <SUITE FILE_PATH="coverage/selling_volatility$test__1_.coverage" NAME="test (1) Coverage Results" MODIFIED="1730494388177" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
     <SUITE FILE_PATH="coverage/selling_volatility$spread_backtest_settlement.coverage" NAME="spread-backtest-settlement Coverage Results" MODIFIED="1729774506154" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
-    <SUITE FILE_PATH="coverage/selling_volatility$production_tastytrade.coverage" NAME="production-tastytrade Coverage Results" MODIFIED="1730817304793" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
+    <SUITE FILE_PATH="coverage/selling_volatility$production_tastytrade.coverage" NAME="production-tastytrade Coverage Results" MODIFIED="1731076343317" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,11 +4,8 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="1728b123-f064-4bc8-9268-077eb1f560ed" name="Changes" comment="added account_monitor_design.md">
+    <list default="true" id="1728b123-f064-4bc8-9268-077eb1f560ed" name="Changes" comment="implemented the account manager, working on allowing the account manager and the strategy script to work together -- dev continues during market hours.">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/poetry.lock" beforeDir="false" afterPath="$PROJECT_DIR$/poetry.lock" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/pyproject.toml" beforeDir="false" afterPath="$PROJECT_DIR$/pyproject.toml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/account_streamer.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/account_monitor.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -23,6 +20,19 @@
     </option>
   </component>
   <component name="Git.Settings">
+    <favorite-branches>
+      <branch-storage>
+        <map>
+          <entry type="LOCAL">
+            <value>
+              <list>
+                <branch-info repo="$PROJECT_DIR$" source="development" />
+              </list>
+            </value>
+          </entry>
+        </map>
+      </branch-storage>
+    </favorite-branches>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
   </component>
   <component name="ProjectColorInfo">{
@@ -38,10 +48,11 @@
     &quot;ASKED_SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
     &quot;Python.production-tastytrade.executor&quot;: &quot;Run&quot;,
     &quot;Python.spread-production.executor&quot;: &quot;Run&quot;,
+    &quot;Python.test (1).executor&quot;: &quot;Run&quot;,
     &quot;Python.test.executor&quot;: &quot;Run&quot;,
     &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
     &quot;git-widget-placeholder&quot;: &quot;development&quot;,
-    &quot;last_opened_file_path&quot;: &quot;C:/Users/marwi/PycharmProjects/halloween-sugar-futures&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/Users/marwi/PycharmProjects/options-momentum-strategy&quot;,
     &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
     &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
     &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
@@ -56,7 +67,7 @@
       <recent name="C:\Users\marwi\PycharmProjects\selling-volatility\src\backtest" />
     </key>
   </component>
-  <component name="RunManager" selected="Python.spread-production">
+  <component name="RunManager" selected="Python.production-tastytrade">
     <configuration name="production-tastytrade" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="selling-volatility" />
       <option name="ENV_FILES" value="" />
@@ -103,6 +114,29 @@
       <option name="INPUT_FILE" value="" />
       <method v="2" />
     </configuration>
+    <configuration name="test (1)" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
+      <module name="selling-volatility" />
+      <option name="ENV_FILES" value="" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        <env name="PYTHONUNBUFFERED" value="1" />
+      </envs>
+      <option name="SDK_HOME" value="" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/src" />
+      <option name="IS_MODULE_SDK" value="true" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/src/test.py" />
+      <option name="PARAMETERS" value="" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
+      <option name="REDIRECT_INPUT" value="false" />
+      <option name="INPUT_FILE" value="" />
+      <method v="2" />
+    </configuration>
     <configuration name="test" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="selling-volatility" />
       <option name="ENV_FILES" value="" />
@@ -128,8 +162,9 @@
     </configuration>
     <recent_temporary>
       <list>
-        <item itemvalue="Python.spread-production" />
         <item itemvalue="Python.production-tastytrade" />
+        <item itemvalue="Python.test (1)" />
+        <item itemvalue="Python.spread-production" />
         <item itemvalue="Python.test" />
       </list>
     </recent_temporary>
@@ -159,6 +194,9 @@
       <workItem from="1730030800314" duration="34857000" />
       <workItem from="1730159235604" duration="25647000" />
       <workItem from="1730466511044" duration="4229000" />
+      <workItem from="1730493883575" duration="10841000" />
+      <workItem from="1730563376002" duration="156000" />
+      <workItem from="1730568028728" duration="1400000" />
     </task>
     <task id="LOCAL-00001" summary="initial reformat">
       <option name="closed" value="true" />
@@ -320,7 +358,15 @@
       <option name="project" value="LOCAL" />
       <updated>1730327899878</updated>
     </task>
-    <option name="localTasksCounter" value="21" />
+    <task id="LOCAL-00021" summary="implemented the account manager, working on allowing the account manager and the strategy script to work together -- dev continues during market hours.">
+      <option name="closed" value="true" />
+      <created>1730554806746</created>
+      <option name="number" value="00021" />
+      <option name="presentableId" value="LOCAL-00021" />
+      <option name="project" value="LOCAL" />
+      <updated>1730554806747</updated>
+    </task>
+    <option name="localTasksCounter" value="22" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -335,6 +381,11 @@
               <RecentGroup>
                 <option name="FILTER_VALUES">
                   <option value="origin/main" />
+                </option>
+              </RecentGroup>
+              <RecentGroup>
+                <option name="FILTER_VALUES">
+                  <option value="main" />
                 </option>
               </RecentGroup>
               <RecentGroup>
@@ -389,13 +440,15 @@
     <MESSAGE value="file tree cleanup" />
     <MESSAGE value="added account_streamer.py" />
     <MESSAGE value="added account_monitor_design.md" />
-    <option name="LAST_COMMIT_MESSAGE" value="added account_monitor_design.md" />
+    <MESSAGE value="implemented the account manager, working on allowing the account manager and the strategy script to work together -- dev continues during market hours." />
+    <option name="LAST_COMMIT_MESSAGE" value="implemented the account manager, working on allowing the account manager and the strategy script to work together -- dev continues during market hours." />
   </component>
   <component name="com.intellij.coverage.CoverageDataManagerImpl">
     <SUITE FILE_PATH="coverage/selling_volatility$spread_production_tastytrade.coverage" NAME="spread-production-tastytrade Coverage Results" MODIFIED="1729865801054" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
     <SUITE FILE_PATH="coverage/selling_volatility$spread_production.coverage" NAME="spread-production Coverage Results" MODIFIED="1730470292763" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
     <SUITE FILE_PATH="coverage/selling_volatility$test.coverage" NAME="test Coverage Results" MODIFIED="1730210511207" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
+    <SUITE FILE_PATH="coverage/selling_volatility$test__1_.coverage" NAME="test (1) Coverage Results" MODIFIED="1730494388177" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
     <SUITE FILE_PATH="coverage/selling_volatility$spread_backtest_settlement.coverage" NAME="spread-backtest-settlement Coverage Results" MODIFIED="1729774506154" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
-    <SUITE FILE_PATH="coverage/selling_volatility$production_tastytrade.coverage" NAME="production-tastytrade Coverage Results" MODIFIED="1730468042247" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
+    <SUITE FILE_PATH="coverage/selling_volatility$production_tastytrade.coverage" NAME="production-tastytrade Coverage Results" MODIFIED="1730554529407" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,8 +4,10 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="1728b123-f064-4bc8-9268-077eb1f560ed" name="Changes" comment="implemented the account manager, working on allowing the account manager and the strategy script to work together -- dev continues during market hours.">
+    <list default="true" id="1728b123-f064-4bc8-9268-077eb1f560ed" name="Changes" comment="get session token cleanup">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/settings.json" beforeDir="false" afterPath="$PROJECT_DIR$/settings.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/production-tastytrade.py" beforeDir="false" afterPath="$PROJECT_DIR$/src/production-tastytrade.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -43,31 +45,55 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ASKED_SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;Python.production-tastytrade.executor&quot;: &quot;Run&quot;,
-    &quot;Python.spread-production.executor&quot;: &quot;Run&quot;,
-    &quot;Python.test (1).executor&quot;: &quot;Run&quot;,
-    &quot;Python.test.executor&quot;: &quot;Run&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;development&quot;,
-    &quot;last_opened_file_path&quot;: &quot;C:/Users/marwi/PycharmProjects/options-momentum-strategy&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ASKED_SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "Python.account-manager.executor": "Run",
+    "Python.production-tastytrade.executor": "Run",
+    "Python.spread-production.executor": "Run",
+    "Python.test (1).executor": "Run",
+    "Python.test.executor": "Run",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "git-widget-placeholder": "development",
+    "last_opened_file_path": "C:/Users/marwi/PycharmProjects/selling-volatility",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="MoveFile.RECENT_KEYS">
       <recent name="C:\Users\marwi\PycharmProjects\selling-volatility\docs" />
       <recent name="C:\Users\marwi\PycharmProjects\selling-volatility\src\backtest" />
     </key>
   </component>
-  <component name="RunManager" selected="Python.production-tastytrade">
+  <component name="RunManager" selected="Python.account-manager">
+    <configuration name="account-manager" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
+      <module name="selling-volatility" />
+      <option name="ENV_FILES" value="" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        <env name="PYTHONUNBUFFERED" value="1" />
+      </envs>
+      <option name="SDK_HOME" value="" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/src" />
+      <option name="IS_MODULE_SDK" value="true" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/src/account-manager.py" />
+      <option name="PARAMETERS" value="" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
+      <option name="REDIRECT_INPUT" value="false" />
+      <option name="INPUT_FILE" value="" />
+      <method v="2" />
+    </configuration>
     <configuration name="production-tastytrade" type="PythonConfigurationType" factoryName="Python" temporary="true" nameIsGenerated="true">
       <module name="selling-volatility" />
       <option name="ENV_FILES" value="" />
@@ -162,9 +188,10 @@
     </configuration>
     <recent_temporary>
       <list>
+        <item itemvalue="Python.account-manager" />
         <item itemvalue="Python.production-tastytrade" />
-        <item itemvalue="Python.test (1)" />
         <item itemvalue="Python.spread-production" />
+        <item itemvalue="Python.test (1)" />
         <item itemvalue="Python.test" />
       </list>
     </recent_temporary>
@@ -197,6 +224,9 @@
       <workItem from="1730493883575" duration="10841000" />
       <workItem from="1730563376002" duration="156000" />
       <workItem from="1730568028728" duration="1400000" />
+      <workItem from="1730583097656" duration="1554000" />
+      <workItem from="1730725505383" duration="5585000" />
+      <workItem from="1730816582951" duration="2420000" />
     </task>
     <task id="LOCAL-00001" summary="initial reformat">
       <option name="closed" value="true" />
@@ -366,7 +396,15 @@
       <option name="project" value="LOCAL" />
       <updated>1730554806747</updated>
     </task>
-    <option name="localTasksCounter" value="22" />
+    <task id="LOCAL-00022" summary="get session token cleanup">
+      <option name="closed" value="true" />
+      <created>1730631773346</created>
+      <option name="number" value="00022" />
+      <option name="presentableId" value="LOCAL-00022" />
+      <option name="project" value="LOCAL" />
+      <updated>1730631773346</updated>
+    </task>
+    <option name="localTasksCounter" value="23" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -441,14 +479,16 @@
     <MESSAGE value="added account_streamer.py" />
     <MESSAGE value="added account_monitor_design.md" />
     <MESSAGE value="implemented the account manager, working on allowing the account manager and the strategy script to work together -- dev continues during market hours." />
-    <option name="LAST_COMMIT_MESSAGE" value="implemented the account manager, working on allowing the account manager and the strategy script to work together -- dev continues during market hours." />
+    <MESSAGE value="get session token cleanup" />
+    <option name="LAST_COMMIT_MESSAGE" value="get session token cleanup" />
   </component>
   <component name="com.intellij.coverage.CoverageDataManagerImpl">
+    <SUITE FILE_PATH="coverage/selling_volatility$account_manager.coverage" NAME="account-manager Coverage Results" MODIFIED="1730821260959" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
     <SUITE FILE_PATH="coverage/selling_volatility$spread_production_tastytrade.coverage" NAME="spread-production-tastytrade Coverage Results" MODIFIED="1729865801054" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
-    <SUITE FILE_PATH="coverage/selling_volatility$spread_production.coverage" NAME="spread-production Coverage Results" MODIFIED="1730470292763" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
+    <SUITE FILE_PATH="coverage/selling_volatility$spread_production.coverage" NAME="spread-production Coverage Results" MODIFIED="1730817273202" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
     <SUITE FILE_PATH="coverage/selling_volatility$test.coverage" NAME="test Coverage Results" MODIFIED="1730210511207" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
     <SUITE FILE_PATH="coverage/selling_volatility$test__1_.coverage" NAME="test (1) Coverage Results" MODIFIED="1730494388177" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
     <SUITE FILE_PATH="coverage/selling_volatility$spread_backtest_settlement.coverage" NAME="spread-backtest-settlement Coverage Results" MODIFIED="1729774506154" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
-    <SUITE FILE_PATH="coverage/selling_volatility$production_tastytrade.coverage" NAME="production-tastytrade Coverage Results" MODIFIED="1730554529407" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
+    <SUITE FILE_PATH="coverage/selling_volatility$production_tastytrade.coverage" NAME="production-tastytrade Coverage Results" MODIFIED="1730817304793" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$/src" />
   </component>
 </project>

--- a/poetry.lock
+++ b/poetry.lock
@@ -1526,6 +1526,20 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "scheduler"
+version = "0.8.7"
+description = "A simple in-process python scheduler library with asyncio, threading and timezone support."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "scheduler-0.8.7-py3-none-any.whl", hash = "sha256:0917fe659a4e62f3d306af7c36f77c5161ef73a7a645bf231db6bd19722b9a3e"},
+    {file = "scheduler-0.8.7.tar.gz", hash = "sha256:ab54d6474649650c5d040b0cc0ae314c636b110fd0dd83254a0481bc93415ee5"},
+]
+
+[package.dependencies]
+typeguard = ">=3.0.0"
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1545,6 +1559,35 @@ python-versions = ">=3.8"
 files = [
     {file = "toolz-1.0.0-py3-none-any.whl", hash = "sha256:292c8f1c4e7516bf9086f8850935c799a874039c8bcf959d47b600e4c44a6236"},
     {file = "toolz-1.0.0.tar.gz", hash = "sha256:2c86e3d9a04798ac556793bced838816296a2f085017664e4995cb40a1047a02"},
+]
+
+[[package]]
+name = "typeguard"
+version = "4.4.1"
+description = "Run-time type checker for Python"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "typeguard-4.4.1-py3-none-any.whl", hash = "sha256:9324ec07a27ec67fc54a9c063020ca4c0ae6abad5e9f0f9804ca59aee68c6e21"},
+    {file = "typeguard-4.4.1.tar.gz", hash = "sha256:0d22a89d00b453b47c49875f42b6601b961757541a2e1e0ef517b6e24213c21b"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.10.0"
+
+[package.extras]
+doc = ["Sphinx (>=7)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme (>=1.3.0)"]
+test = ["coverage[toml] (>=7)", "mypy (>=1.2.0)", "pytest (>=7)"]
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+description = "Backported and Experimental Type Hints for Python 3.8+"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
+    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
 
 [[package]]
@@ -1769,4 +1812,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "cca9128d950cadc097f2963140e7046ecb34b89cf298da820ead81a228d796dc"
+content-hash = "98c1fd1cfbc4dfa4f254236343eb0f1b2aa729b8c35ee9cda9e15295ad07ff9d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1526,18 +1526,18 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
-name = "scheduler"
-version = "0.8.7"
-description = "A simple in-process python scheduler library with asyncio, threading and timezone support."
+name = "schedule"
+version = "1.2.2"
+description = "Job scheduling for humans."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.7"
 files = [
-    {file = "scheduler-0.8.7-py3-none-any.whl", hash = "sha256:0917fe659a4e62f3d306af7c36f77c5161ef73a7a645bf231db6bd19722b9a3e"},
-    {file = "scheduler-0.8.7.tar.gz", hash = "sha256:ab54d6474649650c5d040b0cc0ae314c636b110fd0dd83254a0481bc93415ee5"},
+    {file = "schedule-1.2.2-py3-none-any.whl", hash = "sha256:5bef4a2a0183abf44046ae0d164cadcac21b1db011bdd8102e4a0c1e91e06a7d"},
+    {file = "schedule-1.2.2.tar.gz", hash = "sha256:15fe9c75fe5fd9b9627f3f19cc0ef1420508f9f9a46f45cd0769ef75ede5f0b7"},
 ]
 
-[package.dependencies]
-typeguard = ">=3.0.0"
+[package.extras]
+timezone = ["pytz"]
 
 [[package]]
 name = "six"
@@ -1559,35 +1559,6 @@ python-versions = ">=3.8"
 files = [
     {file = "toolz-1.0.0-py3-none-any.whl", hash = "sha256:292c8f1c4e7516bf9086f8850935c799a874039c8bcf959d47b600e4c44a6236"},
     {file = "toolz-1.0.0.tar.gz", hash = "sha256:2c86e3d9a04798ac556793bced838816296a2f085017664e4995cb40a1047a02"},
-]
-
-[[package]]
-name = "typeguard"
-version = "4.4.1"
-description = "Run-time type checker for Python"
-optional = false
-python-versions = ">=3.9"
-files = [
-    {file = "typeguard-4.4.1-py3-none-any.whl", hash = "sha256:9324ec07a27ec67fc54a9c063020ca4c0ae6abad5e9f0f9804ca59aee68c6e21"},
-    {file = "typeguard-4.4.1.tar.gz", hash = "sha256:0d22a89d00b453b47c49875f42b6601b961757541a2e1e0ef517b6e24213c21b"},
-]
-
-[package.dependencies]
-typing-extensions = ">=4.10.0"
-
-[package.extras]
-doc = ["Sphinx (>=7)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme (>=1.3.0)"]
-test = ["coverage[toml] (>=7)", "mypy (>=1.2.0)", "pytest (>=7)"]
-
-[[package]]
-name = "typing-extensions"
-version = "4.12.2"
-description = "Backported and Experimental Type Hints for Python 3.8+"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
-    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
 
 [[package]]
@@ -1812,4 +1783,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "98c1fd1cfbc4dfa4f254236343eb0f1b2aa729b8c35ee9cda9e15295ad07ff9d"
+content-hash = "5fba3d51b385e8228a74fa8fc0d5e65c9518e5e3da61de26af4a948fd7694a71"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ aiohttp = "^3.10.10"
 polygon-api-client = "^1.14.2"
 pymongo = "4.9"
 motor = "^3.6.0"
+scheduler = "^0.8.7"
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ aiohttp = "^3.10.10"
 polygon-api-client = "^1.14.2"
 pymongo = "4.9"
 motor = "^3.6.0"
-scheduler = "^0.8.7"
+schedule = "^1.2.2"
 
 
 [build-system]

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,7 @@
 {
   "TASTY_SANDBOX_BASE_URL": "https://api.cert.tastyworks.com",
   "TASTY_PRODUCTION_BASE_URL": "https://api.tastyworks.com",
-  "SESSION_SHELF_DIR": "C:\\Users\\marwi\\PycharmProjects\\selling-volatility\\session_shelf"
+  "SESSION_SHELF_DIR": "C:\\Users\\marwi\\PycharmProjects\\selling-volatility\\session_shelf",
+  "MONGO_URI": "mongodb://localhost:27017",
+  "MONGO_DATABASE": "trading_metrics"
 }

--- a/src/account-manager.py
+++ b/src/account-manager.py
@@ -50,6 +50,9 @@ class AccountManager:
             connect_message = {
                 "action": "connect",
                 "value": [settings.ACCOUNT_NUMBER],
+                # TODO: change ACCOUNT_NUMBER such that it takes whatever account number is given back in the request
+                #  for authentication. Means modify authentication to retrieve this and write to variable
+                #  account_number.
                 "auth-token": await self.get_session_token(environment=self.ENVIRONMENT),
                 "request-id": 1
             }

--- a/src/account-manager.py
+++ b/src/account-manager.py
@@ -50,7 +50,7 @@ class AccountManager:
             connect_message = {
                 "action": "connect",
                 "value": [settings.ACCOUNT_NUMBER],
-                "auth-token": await self.get_session_token(),
+                "auth-token": await self.get_session_token(environment=self.ENVIRONMENT),
                 "request-id": 1
             }
             await websocket.send(json.dumps(connect_message))
@@ -194,7 +194,7 @@ class AccountManager:
         logger.warning('Session token expired or invalid, generating new session token...')
 
         # Prepare request parameters based on environment
-        if self == 'sandbox':
+        if self.ENVIRONMENT == 'sandbox':
             url = f"{settings.TASTY_SANDBOX_BASE_URL}/sessions"
             logger.info(f'Using environment:{self} with base url: {url}')
             payload = {

--- a/src/production-tastytrade.py
+++ b/src/production-tastytrade.py
@@ -30,7 +30,7 @@ settings = Dynaconf(
 EnvironmentType = Literal['sandbox', 'production']  # create a type alias
 
 # ENVIRONMENT toggles between sandbox (testing) and production (live trading)
-ENVIRONMENT: EnvironmentType = 'sandbox'
+ENVIRONMENT: EnvironmentType = 'production'
 logger.info(f'Using environment: {ENVIRONMENT}')
 
 

--- a/src/production-tastytrade.py
+++ b/src/production-tastytrade.py
@@ -11,6 +11,7 @@ from dynaconf import Dynaconf
 from typing import Literal
 from pathlib import Path
 from loguru import logger
+import schedule
 
 # Set up a logging directory
 log_dir = Path(__file__).parent / 'logs'
@@ -156,23 +157,6 @@ def get_trading_dates():
     )
 
 
-def is_market_open():
-    """Check if it's exactly market open (09:30 ET)"""
-    et_tz = pytz.timezone('America/New_York')
-    current_time = datetime.now(pytz.UTC).astimezone(et_tz)
-    market_open = current_time.replace(hour=9, minute=30, second=0, microsecond=0)
-
-    # Debug logging
-    logger.info(f"Current ET time: {current_time.strftime('%H:%M:%S')}")
-    logger.info(f"Market open time: {market_open.strftime('%H:%M:%S')}")
-
-    # Get time difference in minutes
-    time_diff = (current_time - market_open).total_seconds() / 60
-
-    # Consider it market open if within 1 minute window
-    return -0.5 <= time_diff <= 0.5
-
-
 def get_vol_regime(polygon_api_key=settings.POLYGON.API_KEY):
     """
     Get the volatility regime based on VIX data.
@@ -215,7 +199,7 @@ def get_underlying_regime(polygon_api_key=settings.POLYGON.API_KEY):
     Raises:
         None
     """
-    date = get_trading_dates()[-1]
+    date = ()[-1]
 
     big_underlying_data = pd.json_normalize(requests.get(
         f"https://api.polygon.io/v2/aggs/ticker/SPY/range/1/day/2020-01-01/{date}"
@@ -484,21 +468,57 @@ def submit_order():
     return submit_order.text
 
 
+def should_execute_trade():
+    """
+    Determine if we should execute the trade based on environment and market conditions
+    """
+    et_tz = pytz.timezone('America/New_York')
+    current_time = datetime.now(pytz.UTC).astimezone(et_tz)
+
+    # If in sandbox, always allow trading
+    if ENVIRONMENT == 'sandbox':
+        logger.info("Sandbox environment - proceeding with trade")
+        return True
+
+    # Check if it's a trading day
+    nyse = get_calendar('NYSE')
+    today = current_time.strftime('%Y-%m-%d')
+    is_trading_day = len(nyse.schedule(start_date=today, end_date=today)) > 0
+
+    if not is_trading_day:
+        logger.info("Not a trading day - skipping trade")
+        return False
+
+    logger.info("Trading day confirmed - proceeding with trade")
+    return True
+
+
+def trading_job():
+    """
+    The job that will be executed at the scheduled time
+    """
+    logger.info("Starting scheduled trading job")
+    if should_execute_trade():
+        try:
+            result = submit_order()
+            logger.info(f"Order submission result: {result}")
+        except Exception as e:
+            logger.error(f"Error executing trade: {str(e)}")
+    else:
+        logger.info("Skipping trade execution based on conditions")
+
+
 if __name__ == '__main__':
+    # Schedule the job for 09:36 ET every day
+    schedule.every().day.at("09:36").do(trading_job)
+
+    # Log initial scheduling
+    et_tz = pytz.timezone('America/New_York')
+    current_time = datetime.now(pytz.UTC).astimezone(et_tz)
+    logger.info(f"Current time (ET): {current_time.strftime('%H:%M:%S')}")
+    logger.info("Trading scheduler initialized - will execute at 09:36 ET each day")
+
+    # Keep the script running
     while True:
-        if is_market_open():
-            logger.info("Market is open - executing market open tasks")
-        elif datetime.now(pytz.timezone('America/New_York')).time() >= pd.Timestamp("09:36").time():
-            logger.info("Trading time reached - executing trading tasks")
-            submit_order()
-            break
-        elif ENVIRONMENT == 'sandbox':
-            """
-            Sandbox orders are always sent, since they are not connected to any real money and are not dependent on 
-            market hours, and are strictly for testing purposes.
-            """
-            submit_order()
-            break
-        else:
-            logger.info("Waiting for market open...")
-            time.sleep(30)  # Check every 30 seconds
+        schedule.run_pending()
+        time.sleep(1)


### PR DESCRIPTION
This update implements scheduling, enabling the tastytrade production script to be run as a continuously running process -- now you no longer need to schedule a task on a cloud provider, you just run the script once and it will keep itself turned on and submit the order when it needs to. Of course we log everything in a clever manner. Also handle sandbox usage, so if we're using it in sandbox mode the order is sent immediately, no scheduling necessary. Scheduling is only necessary in prod mode.

I also start work on the account monitor, which serves to asynchronously monitor open positions and do trade-related accounting.